### PR TITLE
viewer: render footnote attribution via marked-footnote

### DIFF
--- a/src/reference_agent/viewer/static/viz.js
+++ b/src/reference_agent/viewer/static/viz.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 (function () {
+  if (window.markedFootnote) { marked.use(markedFootnote()); }
   const bundle = window.BUNDLE;
   const bundleName = window.BUNDLE_NAME;
   document.title = `${bundleName} — OKF Viewer`;

--- a/src/reference_agent/viewer/templates/viz.html
+++ b/src/reference_agent/viewer/templates/viz.html
@@ -20,6 +20,7 @@
 <title>OKF Bundle Viewer</title>
 <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.28.1/dist/cytoscape.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked-footnote@1.4.0/dist/index.umd.js"></script>
 <style>
 /*__VIZ_CSS__*/
 </style>


### PR DESCRIPTION
## Problem

The bundle viewer renders card bodies with `marked.parse(body, { gfm: true })` (`static/viz.js`). marked's GFM support does not include footnotes — but the spec's per-claim attribution mechanism is markdown footnotes keyed to `sources` entries. So a card that follows the spec's own attribution convention shows its `[^id]` markers as literal text in the viewer's detail panel.

## Fix (two lines)

- `src/reference_agent/viewer/templates/viz.html`: load the UMD build of [marked-footnote](https://github.com/bent10/marked-extensions/tree/main/packages/footnote) from jsdelivr, next to the existing cytoscape/marked CDN scripts;
- `src/reference_agent/viewer/static/viz.js`: `if (window.markedFootnote) { marked.use(markedFootnote()); }` as the first statement of the viewer IIFE.

`[^id]` markers now render as a superscript reference plus the definition block at the end of the body. The guard keeps the viewer working unchanged when the script cannot load (e.g. offline). Pre-generated `bundles/*/viz.html` pick this up the next time they are regenerated.

## Verification

Generated a viewer for a small bundle whose concept body uses `[^spec]` footnote attribution and opened the result: the reference renders as a link, the definition renders as a footnote block, and the graph/sources/backlinks panels are unaffected. With no network access to the CDN the page behaves exactly as before.
